### PR TITLE
Accept benefit parameters on URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -231,6 +231,37 @@ def minnpost_form():
     maximum_choose_multiple_int = int(app.maximum_choose_multiple_level_int['{}'.format(level.get('levelint', 0))])
     maximum_choose_multiple_level_text = num2words(int(app.maximum_choose_multiple_level_int['{}'.format(level.get('levelint', 0))]))
 
+    if request.args.get('swag'):
+        swag = request.args.get('swag')
+    else:
+        swag = ''
+
+    if request.args.get('atlantic_subscription'):
+        atlantic_subscription = request.args.get('atlantic_subscription')
+    else:
+        atlantic_subscription = ''
+
+    if request.args.get('atlantic_id'):
+        atlantic_id = request.args.get('atlantic_id')
+        if atlantic_id != '':
+            atlantic_subscription = ''
+    else:
+        atlantic_id = ''
+
+    if request.args.get('nyt_subscription'):
+        nyt_subscription = request.args.get('nyt_subscription')
+    else:
+        nyt_subscription = ''
+
+    if request.args.get('decline_benefits'):
+        decline_benefits = request.args.get('decline_benefits')
+        if decline_benefits == 'true':
+            swag = ''
+            atlantic_subscription = ''
+            nyt_subscription = ''
+    else:
+        decline_benefits = ''
+
     if request.args.get('firstname'):
         first_name = request.args.get('firstname')
     else:
@@ -276,6 +307,7 @@ def minnpost_form():
         openended_status=openended_status,
         yearly=yearly,
         level=level,
+        swag=swag, atlantic_subscription=atlantic_subscription, atlantic_id=atlantic_id, nyt_subscription=nyt_subscription, decline_benefits=decline_benefits,
         first_name = first_name,last_name = last_name, email=email,
         billing_street = billing_street, billing_city = billing_city, billing_state=billing_state, billing_zip=billing_zip, billing_country=billing_country,
         show_upsell = app.show_upsell, allow_donation_notification = app.allow_donation_notification,

--- a/app.py
+++ b/app.py
@@ -258,6 +258,7 @@ def minnpost_form():
         if decline_benefits == 'true':
             swag = ''
             atlantic_subscription = ''
+            atlantic_id = ''
             nyt_subscription = ''
     else:
         decline_benefits = ''

--- a/app.py
+++ b/app.py
@@ -238,13 +238,13 @@ def minnpost_form():
 
     if request.args.get('atlantic_subscription'):
         atlantic_subscription = request.args.get('atlantic_subscription')
+        if atlantic_subscription != 'true':
+            atlantic_subscription = ''
     else:
         atlantic_subscription = ''
 
     if request.args.get('atlantic_id'):
         atlantic_id = request.args.get('atlantic_id')
-        if atlantic_id != '':
-            atlantic_subscription = ''
     else:
         atlantic_id = ''
 

--- a/salesforce.py
+++ b/salesforce.py
@@ -751,7 +751,7 @@ def _format_opportunity(contact=None, form=None, customer=None, extra_values=Non
         atlantic_subscription = ''
         existing_atlantic_id = ''
 
-    if (atlantic_subscription == 'new' or atlantic_subscription == 'existing'):
+    if atlantic_subscription == 'true':
         atlantic_subscription = 'Yes'
     else:
         atlantic_subscription = 'No'

--- a/templates/includes/review.html
+++ b/templates/includes/review.html
@@ -34,20 +34,20 @@
     <fieldset class="benefits">
       <h2 class="level level--{{ level.levelint }}">MinnPost <span class="level-name">{{ level.level.title() }}</span></h2>  <!-- load server-side from parsing querystring -->
       <p><span class="swag swag--{{ main_swag_minimum_level }}">Choose your thank you gifts below.</span> You can <span class="swag swag--{{ main_swag_minimum_level }}">also</span> <a href="https://www.minnpost.com/support/member-benefits/?level={{ level.level }}" class="review-benefits">review all MinnPost <span class="level-name">{{ level.level.title() }}</span> benefits</a>.</p>  <!-- load server-side from parsing querystring -->
-      <label class="swag swag--{{ main_swag_minimum_level }}"><input type="radio" name="swag" value="mug" id="swag-mug"> <div><img src="/static/img/mug.png" alt="Coffee Mug"></div></label>
-      <label class="swag swag--{{ main_swag_minimum_level }}"><input type="radio" name="swag" value="water bottle" id="swag-bottle"> <div><img src="/static/img/waterbottle.png" alt="Water Bottle"></div></label>
-      <label class="swag swag--{{ top_swag_minimum_level }}"><input type="radio" name="nyt" value="Yes" id="swag-nyt"> <div><img src="/static/img/nyt.png" alt="NYT Digital Subscription"></div></label>
-      <label class="swag swag--{{ main_swag_minimum_level }} total--{{ level.levelint }}"><input type="radio" name="swag" value="None" id="swag-no"> <div>Give entire amount to MinnPost</div></label>
+      <label class="swag swag--{{ main_swag_minimum_level }}"><input type="radio" name="swag" value="mug" id="swag-mug"{% if swag == 'mug' %} checked{% endif %}> <div><img src="/static/img/mug.png" alt="Coffee Mug"></div></label>
+      <label class="swag swag--{{ main_swag_minimum_level }}"><input type="radio" name="swag" value="water bottle" id="swag-bottle"{% if swag == 'waterbottle' %} checked{% endif %}> <div><img src="/static/img/waterbottle.png" alt="Water Bottle"></div></label>
+      <label class="swag swag--{{ top_swag_minimum_level }}"><input type="radio" name="nyt" value="Yes" id="swag-nyt"{% if nyt_subscription == 'true' %} checked{% endif %}> <div><img src="/static/img/nyt.png" alt="NYT Digital Subscription"></div></label>
+      <label class="swag swag--{{ main_swag_minimum_level }} total--{{ level.levelint }}"><input type="radio" name="swag" value="None" id="swag-no"{% if decline_benefits == 'true' %} checked{% endif %}> <div>Give entire amount to MinnPost</div></label>
       <p class="swag swag--separate swag--{{ separate_swag_minimum_level }}">Also, <strong>MinnPost Gold and Platinum</strong> members are entitled to a 1-year subscription to The Atlantic. This offer is available each year that you qualify. More information is available in <a href="/static/documents/atlantic-subscription-details.pdf" target="_blank">this document</a>.</p>
       <fieldset class="swag swag--{{ separate_swag_minimum_level }}">
-        <label><input type="radio" value="new" id="atlantic_new" name="swag_atlanticsubscription" class="swag--shipping"> Start a new subscription</label>
-        <label><input type="radio" value="existing" id="atlantic_existing" name="swag_atlanticsubscription" class="swag--shipping"> Extend an existing subscription</label>
+        <label><input type="radio" value="new" id="atlantic_new" name="swag_atlanticsubscription" class="swag--shipping"{% if atlantic_subscription == 'true' %} checked{% endif %}> Start a new subscription</label>
+        <label><input type="radio" value="existing" id="atlantic_existing" name="swag_atlanticsubscription" class="swag--shipping"{% if atlantic_id != '' %} checked{% endif %}> Extend an existing subscription</label>
         <div class="form-item form-item--atlantic_id" >
           <label>Existing Subscription ID
-          <input type="text" value="" id="atlantic_id" name="atlantic_id" autocorrect="off" autocapitalize="off">
+          <input type="text" value="{% if atlantic_id != '' %}{{ atlantic_id }}{% endif %}" id="atlantic_id" name="atlantic_id" autocorrect="off" autocapitalize="off">
           </label>
         </div>
-        <label><input type="radio" value="No" id="atlantic_decline" name="swag_atlanticsubscription" class="swag--shipping"> Decline this item</label>
+        <label><input type="radio" value="No" id="atlantic_decline" name="swag_atlanticsubscription" class="swag--shipping"{% if decline_benefits == 'true' %} checked{% endif %}> Decline this item</label>
       </fieldset>
       {% if show_thankyou_lists == 'True' %}
         {% if level.levelint < 4 %}

--- a/templates/includes/review.html
+++ b/templates/includes/review.html
@@ -40,8 +40,8 @@
       <label class="swag swag--{{ main_swag_minimum_level }} total--{{ level.levelint }}"><input type="radio" name="swag" value="None" id="swag-no"{% if decline_benefits == 'true' %} checked{% endif %}> <div>Give entire amount to MinnPost</div></label>
       <p class="swag swag--separate swag--{{ separate_swag_minimum_level }}">Also, <strong>MinnPost Gold and Platinum</strong> members are entitled to a 1-year subscription to The Atlantic. This offer is available each year that you qualify. More information is available in <a href="/static/documents/atlantic-subscription-details.pdf" target="_blank">this document</a>.</p>
       <fieldset class="swag swag--{{ separate_swag_minimum_level }}">
-        <label><input type="radio" value="new" id="atlantic_new" name="swag_atlanticsubscription" class="swag--shipping"{% if atlantic_subscription == 'true' %} checked{% endif %}> Start a new subscription</label>
-        <label><input type="radio" value="existing" id="atlantic_existing" name="swag_atlanticsubscription" class="swag--shipping"{% if atlantic_id != '' %} checked{% endif %}> Extend an existing subscription</label>
+        <label><input type="radio" value="new" id="atlantic_new" name="swag_atlanticsubscription" class="swag--shipping"{% if (atlantic_subscription == 'true' and atlantic_id == '') %} checked{% endif %}> Start a new subscription</label>
+        <label><input type="radio" value="existing" id="atlantic_existing" name="swag_atlanticsubscription" class="swag--shipping"{% if (atlantic_subscription == 'true' and atlantic_id != '') %} checked{% endif %}> Extend an existing subscription</label>
         <div class="form-item form-item--atlantic_id" >
           <label>Existing Subscription ID
           <input type="text" value="{% if atlantic_id != '' %}{{ atlantic_id }}{% endif %}" id="atlantic_id" name="atlantic_id" autocorrect="off" autocapitalize="off">


### PR DESCRIPTION
This fixes #27 by accepting the parameters for benefits on the URL.

URL parameters:

- [x] swag=waterbottle
- [x] swag=mug
- [x] atlantic_subscription=true
- [x] atlantic_id=8675309
- [x] nyt_subscription=true
- [x] decline_benefits=true

Test URLs:

- [x] https://mp-st-sf-test.herokuapp.com/give/?step=panel--pay&amount=100&frequency=monthly
- [x] https://mp-st-sf-test.herokuapp.com/give/?amount=100&frequency=monthly